### PR TITLE
Move cron 9 hours later so it includes the completed sanitization flow from the same day

### DIFF
--- a/main_flow.py
+++ b/main_flow.py
@@ -2,7 +2,7 @@ from metaflow import Parameter, step, FlowSpec, schedule, pypi
 import wandb
 
 # Runs each day at 1 AM UTC
-@schedule(cron='0 1 * * ? *', timezone='Etc/UTC')
+@schedule(cron='0 10 * * ? *', timezone='Etc/UTC')
 class SearchTermDataValidationFlow(FlowSpec):
     data_validation_origin = Parameter('data_validation_origin',
                                        help='The table from which to draw the data for validation',


### PR DESCRIPTION
As per @dzeber's reported issue:

> Hey, so this is what I was talking about earlier - from June 25 it looks like the number of test values checked is 1 less than the window setting, for both range and mean across all metrics, eg.
SELECT 
  from_sanitization_job_finished_at, 
  started_at,
  range_test_window_num_days,
  array_length(json_value_array(range_test_vals)) as num_vals_used_range,
  mean_test_window_num_days,
  array_length(json_value_array(mean_test_vals)) as num_vals_used_mean
from `moz-fx-data-shared-prod.search_terms_derived.search_term_data_validation_reports_v1`
where date(started_at) >= '2024-06-01'
and metric = 'pct_sanitized_contained_numbers'
order by started_at
Looking at the code, it looks like this is because the validation job now runs a day later than the sanitization job and the test window is relative to the validation job run, whereas it used to be the same day UTC: https://github.com/mozilla/docker-etl/blob/main/jobs/search-term-data-validation-v2/search_term_data_validation_v2/data_validation.py#L202